### PR TITLE
fix case with defer and named return

### DIFF
--- a/testdata/src/a/defer-named.go
+++ b/testdata/src/a/defer-named.go
@@ -1,0 +1,13 @@
+package a
+
+import (
+	"errors"
+	"fmt"
+)
+
+func myFunc() (err error) {
+	defer func() {}()
+	err = errors.New("my err")
+	_ = fmt.Errorf("%w", err) // want `the error-wrapping message should be "errors\.New: %w"`
+	return err
+}

--- a/testdata/src/a/defer-named.go.golden
+++ b/testdata/src/a/defer-named.go.golden
@@ -1,0 +1,13 @@
+package a
+
+import (
+	"errors"
+	"fmt"
+)
+
+func myFunc() (err error) {
+	defer func() {}()
+	err = errors.New("my err")
+	_ = fmt.Errorf("errors.New: %w", err) // want `the error-wrapping message should be "errors\.New: %w"`
+	return err
+}

--- a/walk.go
+++ b/walk.go
@@ -66,6 +66,10 @@ func (w *walker) walk(ctx context.Context, v ssautil.Poser) ([]string, bool) {
 		return w.walkOperands(ctx, v)
 	case *ssa.Extract:
 		return w.walkOperands(ctx, v)
+	case *ssa.UnOp:
+		if alloc, ok := v.X.(*ssa.Alloc); ok {
+			return w.walkRefs(ctx, alloc)
+		}
 	case *ssa.Call:
 		return formatCall(ctx, v)
 	}

--- a/walk.go
+++ b/walk.go
@@ -67,9 +67,7 @@ func (w *walker) walk(ctx context.Context, v ssautil.Poser) ([]string, bool) {
 	case *ssa.Extract:
 		return w.walkOperands(ctx, v)
 	case *ssa.UnOp:
-		if alloc, ok := v.X.(*ssa.Alloc); ok {
-			return w.walkRefs(ctx, alloc)
-		}
+		return w.walkRefs(ctx, v.X)
 	case *ssa.Call:
 		return formatCall(ctx, v)
 	}


### PR DESCRIPTION

Hello,

I've observed that if there is a `defer` call like this:

```go
func myFunc() error {
	defer func() {}()
	err := errors.New("my err")
	_ = fmt.Errorf("%w", err)
	return err
}
```

or a function with a named return `error` like this:

```go
func myFunc() (err error) {
	err = errors.New("my err")
	_ = fmt.Errorf("%w", err)
	return err
}
```

then the linter works correctly in both cases.

However, if both `defer` call and named return `error` are present like this:

```go
func myFunc() (err error) {
	defer func() {}()
	err = errors.New("my err")
	_ = fmt.Errorf("%w", err)
	return err
}
```

then the linter does not make any suggestion.

I appreciate this tool, especially the `--fix` option, so I forked it and delved into the matter.

It seems like in the last case with both `defer` and named return `err` there is a node of type [`*ssa.UnOp`](https://pkg.go.dev/golang.org/x/tools/go/ssa#UnOp) which is not handled in the walk function.

The type of the field `*ssa.UnOp.X` in this case is `*ssa.Alloc`, that's why I also added this type check (not sure if necessary).

After the changes it works as expected. I also added a small test case.
Feel free to make any adjustment to the changes.

I also wanted to learn more about writing a linter (I am new to this topic): could you suggest some resources?
For example, many linters I saw just use the `ast` package while you also make use of the `ssa` package: what are the advantages?

Thanks